### PR TITLE
Refactor method calls to fix MQL5 deprecated behavior warnings

### DIFF
--- a/Collection/HashMap.mqh
+++ b/Collection/HashMap.mqh
@@ -63,7 +63,7 @@ public:
 
    int               append(Key key,Value value)
      {
-      int ni=append();
+      int ni=HashEntriesBase<Key>::append();
       m_keys[ni]=key;
       m_values[ni]=value;
       return ni;
@@ -71,7 +71,7 @@ public:
 
    void              unremove(int i,Key key,Value value)
      {
-      unremove(i);
+      HashEntriesBase<Key>::unremove(i);
       m_keys[i]=key;
       m_values[i]=value;
      }


### PR DESCRIPTION
This pull request includes changes to the `HashMap.mqh` file to resolve compiler warnings that appear in MQL5 but not in MQL4. The warnings are related to 'deprecated behavior, hidden method calling' which will be disabled in future versions of the MQL compiler. The adjustments ensure the code is future-proof while maintaining backward compatibility with MQL4.

The changes are as follows:
- Explicitly call base class methods in `append` and `unremove` methods to avoid deprecated hidden method calls.

These changes have been tested to ensure that they do not affect the functionality in MQL4 while addressing the deprecated behavior in MQL5.